### PR TITLE
added email_md5 tips for gravatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ Inside jekyll-bootstrap root directory, just run
 $ rake theme:install git="https://github.com/jekyll-bootstrap-3/dbyll-theme"
 ```
 
+Then add this with your email's md5 in _config.yml:  
+
+```yaml
+email_md5 : yourmd5
+```
+
 **New to Jekyll Bootstrap 3?**  
 Visit [Jekyll Bootstrap 3](http://github.com/dbtek/jekyll-bootstrap-3/) for more info.
+
   
 License
 =======


### PR DESCRIPTION
since the email_md5 is not in the default _config.yml, we can add a tips for newcomers like you did for the bootswatch theme
